### PR TITLE
fix: do not fallback

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -12,10 +12,10 @@ module.exports = {
     {
       resolve: 'gatsby-source-cosmicjs',
       options: {
-        bucketSlug: process.env.COSMIC_BUCKET || 'gatsby-blog-cosmic-js',
+        bucketSlug: process.env.COSMIC_BUCKET,
         objectTypes: ['posts','settings'],
         apiAccess: {
-          read_key: process.env.COSMIC_READ_KEY || '6Dx8qaSRsktk6qAIuzLHvxYMTkM1lflQCgX51sQzY4XOlMVq63',
+          read_key: process.env.COSMIC_READ_KEY,
         }
       }
     },


### PR DESCRIPTION
We shouldn't fallback here -- creates a strange experience for end users if they happen to forget to add a key.